### PR TITLE
made fixes to logical operator

### DIFF
--- a/src/baseClient.ts
+++ b/src/baseClient.ts
@@ -10,7 +10,7 @@ function isURLInWhiteList(url: string) {
 
 function responseHandler(response: AxiosResponse<any>): AxiosResponse<any> {
     // eslint-disable-next-line no-constant-condition
-    if (response.config.method === 'GET' || 'get') {
+    if (response.config.method === 'GET' || response.config.method === 'get') {
         if (response.config.url && !isURLInWhiteList(response.config.url)) {
             console.log('storing in cache');
             cache.store(response.config.url, JSON.stringify(response.data));
@@ -29,7 +29,7 @@ function errorHandler(error: any) {
 
 function requestHandler(request: AxiosRequestConfig) {
     // eslint-disable-next-line no-constant-condition
-    if (request.method === 'GET' || 'get') {
+    if (request.method === 'GET' || request.method === 'get') {
         const checkIsValidResponse = cache.isValid(request.url || '');
         if (checkIsValidResponse.isValid) {
             console.log('serving cached data');


### PR DESCRIPTION
I might be wrong, because I am working with Javascript instead of Typescript and I m not familiar with Typescript logical operator syntax, but: 

The following lines in baseClient.ts

`if (request.method === 'GET' || 'get') {`

should be 

`if (request.method === 'GET' || request.method === 'get') {`

no? 

Because this condition `if (request.method === 'GET' || 'get') {` will evaluate to true because the expression 'get' is always true. 

This was a bug that featured in my code, which I've fixed to the latter and it worked. In my particular case, the baseClient is not filtering out POST requests, and I figured this is the problem. 

In any case, great job with this caching mechanism and write up, implemented into my project and it worked :). 